### PR TITLE
Run the GC on function return and remove GC Header from Objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +186,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +276,7 @@ dependencies = [
 name = "nederlang"
 version = "0.1.0"
 dependencies = [
+ "bitvec",
  "criterion",
 ]
 
@@ -337,6 +356,12 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rayon"
@@ -452,6 +477,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "textwrap"
@@ -589,3 +620,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 [features]
 debug = []
 
-[dependencies]
-
 [dev-dependencies]
 criterion =  {version = "0.3", default-features = false }
 
@@ -30,3 +28,6 @@ harness = false
 [[bench]]
 name = "bench_arithmetic"
 harness = false
+
+[dependencies]
+bitvec = "1.0.1"

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -63,15 +63,15 @@ impl GC {
 
     /// Runs a full mark & sweep cycle
     /// Only objects in the given roots are kept alive
-    pub fn run(&mut self, roots: &mut [&mut [Object]]) {
+    pub fn run(&mut self, roots: &[&[Object]]) {
         // Don't traverse roots if we have no traced objects
         if self.objects.is_empty() {
             return;
         }
 
         // Mark all reachable objects
-        for root in roots.iter_mut() {
-            for obj in root.iter_mut() {
+        for root in roots.iter() {
+            for obj in root.iter() {
                 self.mark(obj);
             }
         }
@@ -123,7 +123,7 @@ impl GC {
 
     /// Marks the given object as reachable
     #[inline(always)]
-    fn mark(&mut self, o: &mut Object) {
+    fn mark(&mut self, o: &Object) {
         if !o.is_heap_allocated() {
             return;
         }
@@ -139,7 +139,7 @@ impl GC {
         if o.tag() == Type::Array {
             // Safety: we already checked the type.
             unsafe {
-                for v in o.as_vec_unchecked_mut() {
+                for v in o.as_vec_unchecked() {
                     self.mark(v);
                 }
             }
@@ -153,4 +153,3 @@ impl Drop for GC {
         self.destroy();
     }
 }
-

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -26,6 +26,7 @@ impl GC {
     pub fn maybe_trace(&mut self, o: Object) {
         if o.is_heap_allocated() {
             self.objects.push(o);
+            self.mark_bitmap.reserve(1);
         }
     }
 
@@ -33,6 +34,7 @@ impl GC {
     #[inline]
     pub fn trace(&mut self, o: Object) {
         self.objects.push(o);
+        self.mark_bitmap.reserve(1);
     }
 
     /// Removes the given object (and everything it refers) from this garbage collector so it is no longer managed by it
@@ -52,6 +54,8 @@ impl GC {
                     }
                 }
             }
+
+            self.mark_bitmap.truncate(self.objects.len());
         }
     }
 
@@ -68,6 +72,8 @@ impl GC {
         if self.objects.is_empty() {
             return;
         }
+
+        debug_assert!(self.mark_bitmap.len() >= self.objects.len());
 
         // Mark all reachable objects
         for root in roots.iter() {

--- a/src/object.rs
+++ b/src/object.rs
@@ -426,21 +426,7 @@ impl Object {
     impl_logical!(or, ||);
 }
 
-#[repr(C)]
-pub(crate) struct Header {
-    pub(crate) marked: bool,
-}
-
-impl Header {
-    #[inline]
-    pub unsafe fn read(obj: &mut Object) -> &mut Header {
-        obj.get_mut::<Self>()
-    }
-}
-
-#[repr(C)]
 struct Float {
-    header: Header,
     value: f64,
 }
 
@@ -459,15 +445,12 @@ impl Float {
     fn from_f64(value: f64) -> Object {
         let ptr = Object::with_type(allocate(Layout::new::<Self>()), Type::Float);
         let obj = unsafe { ptr.get_mut::<Self>() };
-        obj.header.marked = false;
         init!(obj.value => value );
         ptr
     }
 }
 
-#[repr(C)]
 struct String {
-    header: Header,
     value: RString,
 }
 
@@ -480,15 +463,12 @@ impl String {
     fn from_string(value: RString) -> Object {
         let ptr = Object::with_type(allocate(Layout::new::<Self>()), Type::String);
         let obj = unsafe { ptr.get_mut::<Self>() };
-        obj.header.marked = false;
         init!(obj.value => value);
         ptr
     }
 }
 
-#[repr(C)]
 struct Array {
-    header: Header,
     value: Vec<Object>,
 }
 
@@ -506,7 +486,6 @@ impl Array {
     fn from_vec(vec: Vec<Object>) -> Object {
         let ptr = Object::with_type(allocate(Layout::new::<Self>()), Type::Array);
         let obj = unsafe { ptr.get_mut::<Self>() };
-        obj.header.marked = false;
         init!(obj.value => vec);
         ptr
     }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -173,7 +173,7 @@ impl VM {
         self.frames[0].base_pointer = 0;
 
         // Keep your friends close
-        let mut constants = code.constants;
+        let constants = code.constants;
         let mut final_result = Object::null();
 
         // Construct a new garbage collector
@@ -377,24 +377,24 @@ impl VM {
                     let result = self.pop();
                     self.popframe();
 
-                    gc.run([
-                        self.stack.as_mut_slice(),
-                        constants.as_mut_slice(),
-                        self.globals.as_mut_slice(),
-                        [final_result, result].as_mut(),
-                    ].as_mut_slice());
+                    gc.run(&[
+                        self.stack.as_slice(),
+                        constants.as_slice(),
+                        self.globals.as_slice(),
+                        &[final_result, result],
+                    ]);
 
                     self.push(result);
                 }
                 OpCode::Return => {
                     self.popframe();
 
-                    gc.run([
-                        self.stack.as_mut_slice(),
-                        constants.as_mut_slice(),
-                        self.globals.as_mut_slice(),
-                        [final_result].as_mut(),
-                    ].as_mut_slice());
+                    gc.run(&[
+                        self.stack.as_slice(),
+                        constants.as_slice(),
+                        self.globals.as_slice(),
+                        &[final_result],
+                    ]);
 
                     self.push(Object::null());
                 }


### PR DESCRIPTION
I was reading your blog post about Nederlang, specifically the one where you convert it from C and optimize it, and while playing with over the weekend it I found a way to make the GC a bit more efficient.

By using a `bitvec::BitVec` to mark reachable objects instead of the `Header` in every `Object`, I was able to make things quite a bit more efficient.  Each commit have details.

